### PR TITLE
Get XML documentation file path from assembly location and codebase

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -131,3 +131,5 @@ $RECYCLE.BIN/
 .DS_Store
 
 _NCrunch*
+
+src/XmlDocFinder/.vs

--- a/src/XmlDocFinder/XmlDocFinder.sln
+++ b/src/XmlDocFinder/XmlDocFinder.sln
@@ -3,7 +3,17 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 16
 VisualStudioVersion = 16.0.31105.61
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "XmlDocFinder", "XmlDocFinder\XmlDocFinder.csproj", "{01229C89-9284-4D38-83F8-45264B292271}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "XmlDocFinder", "XmlDocFinder\XmlDocFinder.csproj", "{01229C89-9284-4D38-83F8-45264B292271}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{894D49A8-F928-42F8-A5CC-221C33945E8B}"
+	ProjectSection(SolutionItems) = preProject
+		..\..\LICENSE = ..\..\LICENSE
+		..\..\README.md = ..\..\README.md
+	EndProjectSection
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Tests", "Tests", "{68D845AC-6A34-4E3B-9C45-7BE6043B8AB7}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "XmlDocFinder.Tests", "..\..\tests\XmlDocFinder.Tests\XmlDocFinder.Tests.csproj", "{1F91C9C9-BF22-46A9-970D-3D98FD3A7519}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -15,9 +25,16 @@ Global
 		{01229C89-9284-4D38-83F8-45264B292271}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{01229C89-9284-4D38-83F8-45264B292271}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{01229C89-9284-4D38-83F8-45264B292271}.Release|Any CPU.Build.0 = Release|Any CPU
+		{1F91C9C9-BF22-46A9-970D-3D98FD3A7519}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{1F91C9C9-BF22-46A9-970D-3D98FD3A7519}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{1F91C9C9-BF22-46A9-970D-3D98FD3A7519}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{1F91C9C9-BF22-46A9-970D-3D98FD3A7519}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{1F91C9C9-BF22-46A9-970D-3D98FD3A7519} = {68D845AC-6A34-4E3B-9C45-7BE6043B8AB7}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {588F60FF-2136-4E08-990A-CC2764855A10}

--- a/src/XmlDocFinder/XmlDocFinder.sln
+++ b/src/XmlDocFinder/XmlDocFinder.sln
@@ -1,0 +1,25 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.31105.61
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "XmlDocFinder", "XmlDocFinder\XmlDocFinder.csproj", "{01229C89-9284-4D38-83F8-45264B292271}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{01229C89-9284-4D38-83F8-45264B292271}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{01229C89-9284-4D38-83F8-45264B292271}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{01229C89-9284-4D38-83F8-45264B292271}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{01229C89-9284-4D38-83F8-45264B292271}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {588F60FF-2136-4E08-990A-CC2764855A10}
+	EndGlobalSection
+EndGlobal

--- a/src/XmlDocFinder/XmlDocFinder/DI/Bootstrap.cs
+++ b/src/XmlDocFinder/XmlDocFinder/DI/Bootstrap.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using SimpleInjector;
+
+namespace Dragonblf.XmlDocFinder.DI
+{
+    /// <summary>
+    /// Contains the dependency injection bootstrap for library.
+    /// </summary>
+    internal static class Bootstrap
+    {
+        /// <summary>
+        /// Apply dependency injection for the base project.
+        /// </summary>
+        /// <param name="container">Dependency injection container to use</param>
+        /// <returns>Dependency injection container</returns>
+        internal static Container Initialize(this Container container)
+        {
+            return container;
+        }
+    }
+}

--- a/src/XmlDocFinder/XmlDocFinder/DI/Bootstrap.cs
+++ b/src/XmlDocFinder/XmlDocFinder/DI/Bootstrap.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.IO.Abstractions;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
@@ -19,6 +20,7 @@ namespace Dragonblf.XmlDocFinder.DI
         /// <returns>Dependency injection container</returns>
         internal static Container Initialize(this Container container)
         {
+            container.Register<IFileSystem, FileSystem>(Lifestyle.Singleton);
             return container;
         }
     }

--- a/src/XmlDocFinder/XmlDocFinder/DI/DIProvider.cs
+++ b/src/XmlDocFinder/XmlDocFinder/DI/DIProvider.cs
@@ -1,0 +1,44 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using SimpleInjector;
+
+namespace Dragonblf.XmlDocFinder.DI
+{
+    /// <summary>
+    /// Provides simple dependency injection functionality.
+    /// </summary>
+    internal static class DIProvider
+    {
+        /// <summary>
+        /// Holds the dependency injection container.
+        /// </summary>
+        private static readonly Container Container;
+
+
+        /// <summary>
+        /// Initializes functionality for <see cref="DIProvider"/>.
+        /// </summary>
+        static DIProvider()
+        {
+            // Create injector container
+            Container = new Container();
+
+            // Initialize dependency injection data
+            Container.Initialize();
+        }
+
+
+        /// <summary>
+        /// Gets an instance of given type <see cref="T"/>.
+        /// </summary>
+        /// <typeparam name="T">Interface to find</typeparam>
+        /// <returns>Instance</returns>
+        public static T GetInstance<T>() where T : class
+        {
+            return Container.GetInstance<T>();
+        }
+    }
+}

--- a/src/XmlDocFinder/XmlDocFinder/DocFinder.cs
+++ b/src/XmlDocFinder/XmlDocFinder/DocFinder.cs
@@ -75,6 +75,27 @@ namespace Dragonblf.XmlDocFinder
             var hash = assembly.FullName.GetHashCode();
             if (Cache.TryGetValue(hash, out path)) { return true; }
 
+            // Get path for assembly or string.Empty if
+            // no XML documentation could be found for
+            // given assembly.
+            path = FindPath(assembly);
+
+            // Save path into cache
+            Cache[hash] = path;
+
+            return true;
+        }
+
+        /// <summary>
+        /// Returns XML documentation path for <paramref name="assembly"/>
+        /// or <see cref="string.Empty"/> if no path could be found.
+        /// </summary>
+        /// <param name="assembly">Assembly for which to get XML documentation path</param>
+        /// <returns>Path to XML documentation path for <paramref name="assembly"/> or <see cref="string.Empty"/> if no path could be found</returns>
+        private string FindPath(in Assembly assembly)
+        {
+            if (assembly == null) { throw new ArgumentNullException(nameof(assembly)); }
+
             throw new NotImplementedException();
         }
     }

--- a/src/XmlDocFinder/XmlDocFinder/DocFinder.cs
+++ b/src/XmlDocFinder/XmlDocFinder/DocFinder.cs
@@ -12,9 +12,9 @@ namespace Dragonblf.XmlDocFinder
     /// </summary>
     public class DocFinder : IDocFinder
     {
-        public string FindFor<T>() where T : new() => FindFor(typeof(T).Assembly);
+        public string FindFor<T>() where T : notnull => FindFor(typeof(T).Assembly);
 
-        public bool TryFindFor<T>(out string path) where T : new() => TryFindFor(typeof(T).Assembly, out path);
+        public bool TryFindFor<T>(out string path) where T : notnull => TryFindFor(typeof(T).Assembly, out path);
 
         public string FindFor(in Assembly assembly)
         {

--- a/src/XmlDocFinder/XmlDocFinder/DocFinder.cs
+++ b/src/XmlDocFinder/XmlDocFinder/DocFinder.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Dragonblf.XmlDocFinder
+{
+    /// <summary>
+    /// Helper class to find paths to XML documentation files for assemblies.
+    /// </summary>
+    public class DocFinder : IDocFinder
+    {
+        public string FindFor<T>() where T : new() => FindFor(typeof(T).Assembly);
+
+        public bool TryFindFor<T>(out string path) where T : new() => TryFindFor(typeof(T).Assembly, out path);
+
+        public string FindFor(in Assembly assembly)
+        {
+            if (assembly == null) { throw new ArgumentNullException(nameof(assembly)); }
+
+            throw new NotImplementedException();
+        }
+
+        public bool TryFindFor(in Assembly assembly, out string path)
+        {
+            if (assembly == null) { throw new ArgumentNullException(nameof(assembly)); }
+
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/src/XmlDocFinder/XmlDocFinder/DocFinder.cs
+++ b/src/XmlDocFinder/XmlDocFinder/DocFinder.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO.Abstractions;
 using System.Linq;
 using System.Reflection;
@@ -94,7 +95,7 @@ namespace Dragonblf.XmlDocFinder
         /// <returns>Path to XML documentation path for <paramref name="assembly"/> or <see cref="string.Empty"/> if no path could be found</returns>
         private string FindPath(in Assembly assembly)
         {
-            if (assembly == null) { throw new ArgumentNullException(nameof(assembly)); }
+            Debug.Assert(assembly != null, "assembly != null");
 
             throw new NotImplementedException();
         }

--- a/src/XmlDocFinder/XmlDocFinder/DocFinder.cs
+++ b/src/XmlDocFinder/XmlDocFinder/DocFinder.cs
@@ -97,7 +97,7 @@ namespace Dragonblf.XmlDocFinder
         {
             Debug.Assert(assembly != null, "assembly != null");
 
-            throw new NotImplementedException();
+            return string.Empty;
         }
     }
 }

--- a/src/XmlDocFinder/XmlDocFinder/DocFinder.cs
+++ b/src/XmlDocFinder/XmlDocFinder/DocFinder.cs
@@ -1,9 +1,11 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.IO.Abstractions;
 using System.Linq;
 using System.Reflection;
 using System.Text;
 using System.Threading.Tasks;
+using Dragonblf.XmlDocFinder.DI;
 
 namespace Dragonblf.XmlDocFinder
 {
@@ -12,6 +14,33 @@ namespace Dragonblf.XmlDocFinder
     /// </summary>
     public class DocFinder : IDocFinder
     {
+        /// <summary>
+        /// Contains the file system wrapper to use.
+        /// </summary>
+        private IFileSystem _fileSystem;
+
+
+        /// <summary>
+        /// Initializes a new instance of <see cref="DocFinder"/>.
+        /// </summary>
+        public DocFinder()
+        {
+            _fileSystem = DIProvider.GetInstance<IFileSystem>();
+        }
+
+        /// <summary>
+        /// Initializes a new instance of <see cref="DocFinder"/>.
+        /// </summary>
+        /// <param name="fileSystem">File system wrapper to use</param>
+        /// <exception cref="ArgumentNullException"></exception>
+        internal DocFinder(IFileSystem fileSystem)
+        {
+            if (fileSystem == null) { throw new ArgumentNullException(nameof(fileSystem)); }
+
+            _fileSystem = fileSystem;
+        }
+
+
         public string FindFor<T>() where T : notnull => FindFor(typeof(T).Assembly);
 
         public bool TryFindFor<T>(out string path) where T : notnull => TryFindFor(typeof(T).Assembly, out path);

--- a/src/XmlDocFinder/XmlDocFinder/DocFinder.cs
+++ b/src/XmlDocFinder/XmlDocFinder/DocFinder.cs
@@ -49,7 +49,9 @@ namespace Dragonblf.XmlDocFinder
         {
             if (assembly == null) { throw new ArgumentNullException(nameof(assembly)); }
 
-            throw new NotImplementedException();
+            return TryFindFor(assembly, out var path) 
+                ? path 
+                : string.Empty;
         }
 
         public bool TryFindFor(in Assembly assembly, out string path)

--- a/src/XmlDocFinder/XmlDocFinder/DocFinder.cs
+++ b/src/XmlDocFinder/XmlDocFinder/DocFinder.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.IO.Abstractions;
 using System.Linq;
@@ -14,6 +15,13 @@ namespace Dragonblf.XmlDocFinder
     /// </summary>
     public class DocFinder : IDocFinder
     {
+        /// <summary>
+        /// Contains previously found XML documentation
+        /// paths for hashes of assembly full names.
+        /// </summary>
+        private static readonly IDictionary<int, string> Cache =
+            new ConcurrentDictionary<int, string>();
+
         /// <summary>
         /// Contains the file system wrapper to use.
         /// </summary>
@@ -57,6 +65,15 @@ namespace Dragonblf.XmlDocFinder
         public bool TryFindFor(in Assembly assembly, out string path)
         {
             if (assembly == null) { throw new ArgumentNullException(nameof(assembly)); }
+            if (string.IsNullOrWhiteSpace(assembly.FullName))
+            {
+                throw new ArgumentException("Full name of assembly needs to be defined and not only white spaces", nameof(assembly));
+            }
+
+            // Check if cache contains previously found
+            // path for given assembly
+            var hash = assembly.FullName.GetHashCode();
+            if (Cache.TryGetValue(hash, out path)) { return true; }
 
             throw new NotImplementedException();
         }

--- a/src/XmlDocFinder/XmlDocFinder/IDocFinder.cs
+++ b/src/XmlDocFinder/XmlDocFinder/IDocFinder.cs
@@ -19,7 +19,7 @@ namespace Dragonblf.XmlDocFinder
         /// </summary>
         /// <typeparam name="T">Type for which declaring assembly to find the XML documentation file path</typeparam>
         /// <returns>Path to XML documentation file if path was found else <see cref="string.Empty"/></returns>
-        public string FindFor<T>() where T : new();
+        public string FindFor<T>() where T : notnull;
 
         /// <summary>
         /// Finds XML documentation file path for assembly declaring
@@ -28,7 +28,7 @@ namespace Dragonblf.XmlDocFinder
         /// <typeparam name="T">Type for which declaring assembly to find the XML documentation file path</typeparam>
         /// <param name="path">Path to XML documentation file if path was found else <see cref="string.Empty"/></param>
         /// <returns>True if path to XML documentation file was found otherwise false</returns>
-        public bool TryFindFor<T>(out string path) where T : new();
+        public bool TryFindFor<T>(out string path) where T : notnull;
 
         /// <summary>
         /// Finds XML documentation file path for <paramref name="assembly"/>.

--- a/src/XmlDocFinder/XmlDocFinder/IDocFinder.cs
+++ b/src/XmlDocFinder/XmlDocFinder/IDocFinder.cs
@@ -1,0 +1,50 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Dragonblf.XmlDocFinder
+{
+    /// <summary>
+    /// Interface which defines helper methods to implement
+    /// to find paths to XML documentation files for assemblies.
+    /// </summary>
+    public interface IDocFinder
+    {
+        /// <summary>
+        /// Finds XML documentation file path for assembly declaring
+        /// <typeparamref name="T"/>.
+        /// </summary>
+        /// <typeparam name="T">Type for which declaring assembly to find the XML documentation file path</typeparam>
+        /// <returns>Path to XML documentation file if path was found else <see cref="string.Empty"/></returns>
+        public string FindFor<T>() where T : new();
+
+        /// <summary>
+        /// Finds XML documentation file path for assembly declaring
+        /// <typeparamref name="T"/>.
+        /// </summary>
+        /// <typeparam name="T">Type for which declaring assembly to find the XML documentation file path</typeparam>
+        /// <param name="path">Path to XML documentation file if path was found else <see cref="string.Empty"/></param>
+        /// <returns>True if path to XML documentation file was found otherwise false</returns>
+        public bool TryFindFor<T>(out string path) where T : new();
+
+        /// <summary>
+        /// Finds XML documentation file path for <paramref name="assembly"/>.
+        /// </summary>
+        /// <param name="assembly">Assembly for which to find its XML documentation file path</param>
+        /// <exception cref="ArgumentNullException"></exception>
+        /// <returns>Path to XML documentation file if path was found else <see cref="string.Empty"/></returns>
+        public string FindFor(in Assembly assembly);
+
+        /// <summary>
+        /// Finds XML documentation file path for <paramref name="assembly"/>.
+        /// </summary>
+        /// <param name="assembly">Assembly for which to find its XML documentation file path</param>
+        /// <param name="path">Path to XML documentation file if path was found else <see cref="string.Empty"/></param>
+        /// <exception cref="ArgumentNullException"></exception>
+        /// <returns>True if path to XML documentation file was found otherwise false</returns>
+        public bool TryFindFor(in Assembly assembly, out string path);
+    }
+}

--- a/src/XmlDocFinder/XmlDocFinder/XmlDocFinder.csproj
+++ b/src/XmlDocFinder/XmlDocFinder/XmlDocFinder.csproj
@@ -5,4 +5,8 @@
     <RootNamespace>Dragonblf.XmlDocFinder</RootNamespace>
   </PropertyGroup>
 
+  <ItemGroup>
+    <PackageReference Include="SimpleInjector" Version="5.3.2" />
+  </ItemGroup>
+
 </Project>

--- a/src/XmlDocFinder/XmlDocFinder/XmlDocFinder.csproj
+++ b/src/XmlDocFinder/XmlDocFinder/XmlDocFinder.csproj
@@ -7,6 +7,16 @@
 
   <ItemGroup>
     <PackageReference Include="SimpleInjector" Version="5.3.2" />
+    <PackageReference Include="System.IO.Abstractions" Version="13.2.43" />
+  </ItemGroup>
+
+  <ItemGroup>
+	<AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
+	  <_Parameter1>$(AssemblyName).Tests</_Parameter1>
+	</AssemblyAttribute>
+	<AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
+	  <_Parameter1>DynamicProxyGenAssembly2</_Parameter1>
+	</AssemblyAttribute>
   </ItemGroup>
 
 </Project>

--- a/src/XmlDocFinder/XmlDocFinder/XmlDocFinder.csproj
+++ b/src/XmlDocFinder/XmlDocFinder/XmlDocFinder.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <RootNamespace>Dragonblf.XmlDocFinder</RootNamespace>
+  </PropertyGroup>
+
+</Project>

--- a/tests/XmlDocFinder.Tests/DocFinderTests.cs
+++ b/tests/XmlDocFinder.Tests/DocFinderTests.cs
@@ -1,0 +1,69 @@
+using Dragonblf.XmlDocFinder;
+using System;
+using Xunit;
+using System.Reflection;
+using FakeItEasy;
+using Shouldly;
+
+namespace XmlDocFinder.Tests
+{
+    public class DocFinderTests
+    {
+        private DocFinder _testClass;
+
+        private Assembly _assembly;
+
+
+        public DocFinderTests()
+        {
+            _testClass = new DocFinder();
+            _assembly = A.Fake<Assembly>();
+        }
+
+
+        [Fact]
+        public void Can_Construct()
+        {
+            var instance = new DocFinder();
+            instance.ShouldNotBeNull();
+        }
+
+        [Fact]
+        public void Call_FindForT_WithType_NotImplementedException()
+        {
+            Should.Throw<NotImplementedException>(() => _testClass.FindFor<object>());
+        }
+
+        [Fact]
+        public void Call_TryFindForT_WithType_NotImplementedException()
+        {
+            Should.Throw<NotImplementedException>(() => _testClass.TryFindFor<object>(out var path));
+        }
+
+        [Fact]
+        public void Call_FindFor_WithAssembly_NotImplementedException()
+        {
+            Should.Throw<NotImplementedException>(() => _testClass.FindFor(_assembly));
+        }
+
+        [Fact]
+        public void Call_FindFor_WithNull_ArgumentNullException()
+        {
+            Assembly assembly = null;
+            Should.Throw<ArgumentNullException>(() => _testClass.FindFor(assembly));
+        }
+
+        [Fact]
+        public void Call_TryFindFor_WithAssembly_NotImplementedException()
+        {
+            Should.Throw<NotImplementedException>(() => _testClass.TryFindFor(_assembly, out var path));
+        }
+
+        [Fact]
+        public void Call_TryFindFor_WithNull_ArgumentNullException()
+        {
+            Assembly assembly = null;
+            Should.Throw<ArgumentNullException>(() => _testClass.TryFindFor(assembly, out var path));
+        }
+    }
+}

--- a/tests/XmlDocFinder.Tests/DocFinderTests.cs
+++ b/tests/XmlDocFinder.Tests/DocFinderTests.cs
@@ -1,5 +1,6 @@
 using Dragonblf.XmlDocFinder;
 using System;
+using System.IO.Abstractions;
 using Xunit;
 using System.Reflection;
 using FakeItEasy;
@@ -13,10 +14,13 @@ namespace XmlDocFinder.Tests
 
         private Assembly _assembly;
 
+        private IFileSystem _fileSystem;
+
 
         public DocFinderTests()
         {
-            _testClass = new DocFinder();
+            _fileSystem = A.Fake<IFileSystem>();
+            _testClass = new DocFinder(_fileSystem);
             _assembly = A.Fake<Assembly>();
         }
 

--- a/tests/XmlDocFinder.Tests/DocFinderTests.cs
+++ b/tests/XmlDocFinder.Tests/DocFinderTests.cs
@@ -47,6 +47,7 @@ namespace XmlDocFinder.Tests
         [Fact]
         public void Call_FindFor_WithAssembly_NotImplementedException()
         {
+            A.CallTo(() => _assembly.FullName).Returns("path");
             Should.Throw<NotImplementedException>(() => _testClass.FindFor(_assembly));
         }
 
@@ -60,6 +61,7 @@ namespace XmlDocFinder.Tests
         [Fact]
         public void Call_TryFindFor_WithAssembly_NotImplementedException()
         {
+            A.CallTo(() => _assembly.FullName).Returns("path");
             Should.Throw<NotImplementedException>(() => _testClass.TryFindFor(_assembly, out var path));
         }
 
@@ -68,6 +70,16 @@ namespace XmlDocFinder.Tests
         {
             Assembly assembly = null;
             Should.Throw<ArgumentNullException>(() => _testClass.TryFindFor(assembly, out var path));
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        [InlineData("   ")]
+        public void Call_TryFindFor_WithWrongFullName_ArgumentException(string value)
+        {
+            A.CallTo(() => _assembly.FullName).Returns(value);
+            Should.Throw<ArgumentException>(() => _testClass.TryFindFor(_assembly, out var path));
         }
     }
 }

--- a/tests/XmlDocFinder.Tests/DocFinderTests.cs
+++ b/tests/XmlDocFinder.Tests/DocFinderTests.cs
@@ -33,22 +33,30 @@ namespace XmlDocFinder.Tests
         }
 
         [Fact]
-        public void Call_FindForT_WithType_NotImplementedException()
+        public void Call_FindForT_WithType_EmptyString()
         {
-            Should.Throw<NotImplementedException>(() => _testClass.FindFor<object>());
+            var path = _testClass.FindFor<object>();
+
+            path.ShouldBe(string.Empty);
         }
 
         [Fact]
-        public void Call_TryFindForT_WithType_NotImplementedException()
+        public void Call_TryFindForT_WithType_EmptyString()
         {
-            Should.Throw<NotImplementedException>(() => _testClass.TryFindFor<object>(out var path));
+            var result = _testClass.TryFindFor<object>(out var path);
+
+            result.ShouldBeTrue();
+            path.ShouldBe(string.Empty);
         }
 
         [Fact]
-        public void Call_FindFor_WithAssembly_NotImplementedException()
+        public void Call_FindFor_WithAssembly_EmptyString()
         {
             A.CallTo(() => _assembly.FullName).Returns("path");
-            Should.Throw<NotImplementedException>(() => _testClass.FindFor(_assembly));
+
+            var path = _testClass.FindFor(_assembly);
+
+            path.ShouldBe(string.Empty);
         }
 
         [Fact]
@@ -59,10 +67,14 @@ namespace XmlDocFinder.Tests
         }
 
         [Fact]
-        public void Call_TryFindFor_WithAssembly_NotImplementedException()
+        public void Call_TryFindFor_WithAssembly_EmptyString()
         {
             A.CallTo(() => _assembly.FullName).Returns("path");
-            Should.Throw<NotImplementedException>(() => _testClass.TryFindFor(_assembly, out var path));
+
+            var result = _testClass.TryFindFor(_assembly, out var path);
+
+            result.ShouldBeTrue();
+            path.ShouldBe(string.Empty);
         }
 
         [Fact]

--- a/tests/XmlDocFinder.Tests/XmlDocFinder.Tests.csproj
+++ b/tests/XmlDocFinder.Tests/XmlDocFinder.Tests.csproj
@@ -7,8 +7,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FakeItEasy" Version="7.1.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
+    <PackageReference Include="NSubstitute" Version="4.2.2" />
     <PackageReference Include="Shouldly" Version="4.0.3" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">

--- a/tests/XmlDocFinder.Tests/XmlDocFinder.Tests.csproj
+++ b/tests/XmlDocFinder.Tests/XmlDocFinder.Tests.csproj
@@ -1,0 +1,28 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="FakeItEasy" Version="7.1.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
+    <PackageReference Include="Shouldly" Version="4.0.3" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="1.3.0">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\XmlDocFinder\XmlDocFinder\XmlDocFinder.csproj" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
# Description
Adds functionality to get XML documentation path from [location](https://docs.microsoft.com/de-de/dotnet/api/system.reflection.assembly.location?view=netcore-3.0#System_Reflection_Assembly_Location) and [codebase](https://docs.microsoft.com/de-de/dotnet/api/system.reflection.assembly.codebase?view=netcore-3.0#System_Reflection_Assembly_CodeBase) from an assembly. This will close #2.

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change is documentated in code
- [ ] This change requires a documentation update